### PR TITLE
Move IPv6 bogon to bogon

### DIFF
--- a/guides/bogon_prefixes.md
+++ b/guides/bogon_prefixes.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: Bogon Prefixes
-permalink: /guides/bogons/
+permalink: /guides/bogon_prefixes/
 ---
 
 * TOC

--- a/guides/bogons.md
+++ b/guides/bogons.md
@@ -1,20 +1,22 @@
 ---
 layout: page
-title: IPv6 Bogon Prefixes
-permalink: /guides/ipv6_bogons/
+title: Bogon Prefixes
+permalink: /guides/bogons/
 ---
 
 * TOC
 {:toc}
 
-# Filter IPv6 Bogon prefixes
+# Filter Bogon prefixes
 
 ## Purpose
 
-These prefixes are not globally unique unicast prefixes. IETF didn't intend for
+These prefixes are not globally unique prefixes. IETF didn't intend for
 these to be routed on the public Internet.
 
-# Configuration Examples
+# Configuration Examples IPv4
+
+# Configuration Examples IPv6
 
 ## OpenBGPD
 


### PR DESCRIPTION
Not sure if this request will be accepted. Would it not be ideal to have this file for both v4 and v6 bogons? I think there is some use in an IPv4 bogon configuration.

If so, we could either have a separate v4 file, or merge both v4 and v6 into a single bogon file.