### PR TITLE
Update graceful_shutdown.md

### DIFF
--- a/guides/graceful_shutdown.md
+++ b/guides/graceful_shutdown.md
@@ -160,3 +160,4 @@ exit
 * Thomas King / AS 31451
 * KPN Eurorings (International) / AS286
 * The Wikimedia Foundation / AS14907
+* DigitalOcean / AS14061


### PR DESCRIPTION
Adding DigitalOcean / AS14061 to the list of networks that accept G-shut