### PR TITLE
Configuration examples of Bogon v4/v6 prefixes filtering for Nokia SR OS

### DIFF
--- a/guides/bogon_prefixes.md
+++ b/guides/bogon_prefixes.md
@@ -147,6 +147,134 @@ route-policy BGP_FILTER_IN
   endif
 end-policy
 ```
+## Nokia SR OS
+```
+#
+# Classic CLI
+#
+#--------------------------------------------------
+echo "Policy Configuration"
+#--------------------------------------------------
+        policy-options
+            begin
+            prefix-list "BOGONS_V4"
+                prefix 0.0.0.0/8 exact
+                prefix 10.0.0.0/8 exact
+                prefix 100.64.0.0/10 exact
+                prefix 127.0.0.0/8 exact
+                prefix 169.254.0.0/16 exact
+                prefix 172.16.0.0/12 exact
+                prefix 192.0.2.0/24 exact
+                prefix 192.88.99.0/24 exact
+                prefix 192.168.0.0/16 exact
+                prefix 198.18.0.0/15 exact
+                prefix 198.51.100.0/24 exact
+                prefix 203.0.113.0/24 exact
+                prefix 224.0.0.0/4 exact
+                prefix 240.0.0.0/4 exact
+            exit
+            policy-statement "BGP_FILTER_IN"
+                entry 10
+                    from
+                        prefix-list "BOGONS_V4"
+                    exit
+                    action drop
+                    exit
+                exit
+            exit
+            commit
+        exit
+----------------------------------------------
+
+#
+# Paste-friendly Classic CLI blob
+#
+/configure router policy-options begin
+/configure router policy-options prefix-list "BOGONS_V4" prefix 0.0.0.0/8 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 10.0.0.0/8 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 100.64.0.0/10 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 127.0.0.0/8 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 169.254.0.0/16 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 172.16.0.0/12 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 192.0.2.0/24 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 192.88.99.0/24 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 192.168.0.0/16 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 198.18.0.0/15 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 198.51.100.0/24 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 203.0.113.0/24 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 224.0.0.0/4 exact
+/configure router policy-options prefix-list "BOGONS_V4" prefix 240.0.0.0/4 exact
+/configure router policy-options policy-statement "BGP_FILTER_IN" entry 10 from prefix-list "BOGONS_V4"
+/configure router policy-options policy-statement "BGP_FILTER_IN" entry 10 action drop
+/configure router policy-options commit
+
+#
+# Model-Driven CLI (MD-CLI)
+#
+[gl:configure policy-options]
+    prefix-list "BOGONS_V4" {
+        prefix 0.0.0.0/8 type exact {
+        }
+        prefix 10.0.0.0/8 type exact {
+        }
+        prefix 100.64.0.0/10 type exact {
+        }
+        prefix 127.0.0.0/8 type exact {
+        }
+        prefix 169.254.0.0/16 type exact {
+        }
+        prefix 172.16.0.0/12 type exact {
+        }
+        prefix 192.0.2.0/24 type exact {
+        }
+        prefix 192.88.99.0/24 type exact {
+        }
+        prefix 192.168.0.0/16 type exact {
+        }
+        prefix 198.18.0.0/15 type exact {
+        }
+        prefix 198.51.100.0/24 type exact {
+        }
+        prefix 203.0.113.0/24 type exact {
+        }
+        prefix 224.0.0.0/4 type exact {
+        }
+        prefix 240.0.0.0/4 type exact {
+        }
+    }
+    policy-statement "BGP_FILTER_IN" {
+    entry 10 {
+        from {
+            prefix-list ["BOGONS_V4"]
+        }
+        action {
+            action-type reject
+        }
+    }
+
+#
+# Paste-friendly MD-CLI blob
+#
+/configure policy-options prefix-list "BOGONS_V4" { }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 0.0.0.0/8 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 10.0.0.0/8 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 100.64.0.0/10 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 127.0.0.0/8 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 169.254.0.0/16 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 172.16.0.0/12 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 192.0.2.0/24 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 192.88.99.0/24 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 192.168.0.0/16 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 198.18.0.0/15 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 198.51.100.0/24 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 203.0.113.0/24 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 224.0.0.0/4 type exact }
+/configure policy-options prefix-list "BOGONS_V4" { prefix 240.0.0.0/4 type exact }
+/configure policy-options policy-statement "BGP_FILTER_IN" { }
+/configure policy-options policy-statement "BGP_FILTER_IN" { entry 10 }
+/configure policy-options policy-statement "BGP_FILTER_IN" entry 10 from prefix-list ["BOGONS_V4"]
+/configure policy-options policy-statement "BGP_FILTER_IN" entry 10 action action-type reject
+```
 # Configuration Examples IPv6
 
 ## BIRD
@@ -226,3 +354,116 @@ Gert Doering's [ipv6-filters](https://www.space.net/~gert/RIPE/ipv6-filters.html
 ## YAML from Coloclue
 
 Coloclue's network management system [kees](https://github.com/coloclue/kees) considers these the IPv6 Bogons: [yaml file](https://github.com/coloclue/kees/blob/master/vars_example/generic.yml#L188-L274)
+
+## Nokia SR OS
+```
+#
+# Classic CLI
+#
+#--------------------------------------------------
+echo "Policy Configuration"
+#--------------------------------------------------
+        policy-options
+            begin
+            prefix-list "BOGONS_V6"
+                prefix ::/8 longer
+                prefix 100::/64 longer
+                prefix 2001:2::/48 longer
+                prefix 2001:10::/28 longer
+                prefix 2001:db8::/32 longer
+                prefix 2002::/16 longer
+                prefix 3ffe::/16 longer
+                prefix fc00::/7 longer
+                prefix fe80::/10 longer
+                prefix fec0::/10 longer
+                prefix ff00::/8 longer
+            exit
+            policy-statement "BGP_FILTER_IN"
+                entry 20
+                    from
+                        prefix-list "BOGONS_V6"
+                    exit
+                    action drop
+                    exit
+                exit
+            exit
+            commit
+        exit
+
+#
+# Paste-friendly Classic CLI blob
+#
+/configure router policy-options begin
+/configure router policy-options prefix-list "BOGONS_V6" prefix ::/8 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix 100::/64 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix 2001:2::/48 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix 2001:10::/28 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix 2001:db8::/32 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix 2002::/16 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix 3ffe::/16 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix fc00::/7 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix fe80::/10 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix fec0::/10 longer
+/configure router policy-options prefix-list "BOGONS_V6" prefix ff00::/8 longer
+/configure router policy-options policy-statement "BGP_FILTER_IN" entry 20 from prefix-list "BOGONS_V6"
+/configure router policy-options policy-statement "BGP_FILTER_IN" entry 20 action drop
+/configure router policy-options commit
+
+#
+# Model-driven CLI (MD-CLI)
+#
+[gl:configure policy-options]
+    prefix-list "BOGONS_V6" {
+        prefix ::/8 type longer {
+        }
+        prefix 100::/64 type longer {
+        }
+        prefix 2001:2::/48 type longer {
+        }
+        prefix 2001:10::/28 type longer {
+        }
+        prefix 2001:db8::/32 type longer {
+        }
+        prefix 2002::/16 type longer {
+        }
+        prefix 3ffe::/16 type longer {
+        }
+        prefix fc00::/7 type longer {
+        }
+        prefix fe80::/10 type longer {
+        }
+        prefix fec0::/10 type longer {
+        }
+        prefix ff00::/8 type longer {
+        }
+    }
+    policy-statement "BGP_FILTER_IN" {
+        entry 20 {
+            from {
+                prefix-list ["BOGONS_V6"]
+            }
+            action {
+                action-type reject
+            }
+        }
+    }
+
+#
+# Paste-friendly MD-CLI blob
+#
+/configure policy-options prefix-list "BOGONS_V6" { }
+/configure policy-options prefix-list "BOGONS_V6" { prefix ::/8 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix 100::/64 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix 2001:2::/48 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix 2001:10::/28 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix 2001:db8::/32 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix 2002::/16 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix 3ffe::/16 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix fc00::/7 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix fe80::/10 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix fec0::/10 type longer }
+/configure policy-options prefix-list "BOGONS_V6" { prefix ff00::/8 type longer }
+/configure policy-options policy-statement "BGP_FILTER_IN" { entry 20 }
+/configure policy-options policy-statement "BGP_FILTER_IN" entry 20 from prefix-list ["BOGONS_V6"]
+/configure policy-options policy-statement "BGP_FILTER_IN" entry 20 action action-type reject
+```


### PR DESCRIPTION
Hi *,
The config examples are provided for both Classic CLI and MD-CLI (model-driven CLI) in a configuration file and paste-friendly variants.

/cc @jonasvermeulen
