### PR TITLE
style: swap custom text selection coloring

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -122,12 +122,12 @@ img {
 
 // Specify the color of the selection
 ::-moz-selection {
-  color: $black;
-  background: $lightGray;
+  color: $lightGray;
+  background: $black;
 }
 ::selection {
-  color: $black;
-  background: $lightGray;
+  color: $lightGray;
+  background: $black;
 }
 
 // Nicolas Gallagher's micro clearfix hack


### PR DESCRIPTION
Currently i find it really hard to copy code examples. The reason is that the selection color is the same as the Box used for the code. I don't know if this is intentionally?

This PR aims to swap the used colors, but just removing the custom coloring would also work. I would like to here some opinions.

## Screenshots

### Current Situation

I marked some text, who can spot it? :wink:

![image](https://user-images.githubusercontent.com/15121114/120570594-c814d600-c418-11eb-8152-6b63b8d04d70.png)

### With Modification

With this PR it should look like this:

![image](https://user-images.githubusercontent.com/15121114/120570882-5426fd80-c419-11eb-8091-6fbffadfa677.png)
