### PR TITLE
Add examples for RouterOS v7

### DIFF
--- a/guides/bogon_asns.md
+++ b/guides/bogon_asns.md
@@ -229,10 +229,10 @@ This is not recommanded. Mikrotik will take a very very long time to process all
 /routing/filter/num-list 
 add list=BOGON-AS range=0 comment="RFC 7607"
 add list=BOGON-AS range=23456 comment="RFC 4893 AS_TRANS"
-add list=BOGON-AS range=64496-64511" comment="RFC 5398"
-add list=BOGON-AS range=64512-65534" comment="RFC 6996"
+add list=BOGON-AS range=64496-64511 comment="RFC 5398"
+add list=BOGON-AS range=64512-65534 comment="RFC 6996"
 add list=BOGON-AS range=65535 comment="RFC 7300"
-add list=BOGON-AS range=65536-65551" comment="RFC 5398"
+add list=BOGON-AS range=65536-65551 comment="RFC 5398"
 add list=BOGON-AS range=65552-131071 comment="Reserved"
 add list=BOGON-AS range=4200000000-4294967294 comment="RFC 6996"
 add list=BOGON-AS range=4294967294 comment="RFC 7300"

--- a/guides/bogon_asns.md
+++ b/guides/bogon_asns.md
@@ -207,6 +207,8 @@ bgp as-path access-list bogon-asns deny 4200000000-4294967295
 ```
 
 ## Mikrotik
+
+### RouterOS v6
 This is not recommanded. Mikrotik will take a very very long time to process all those routes and has some issues with BGP.
 ```
 /routing filter add chain=GENERIC_PREFIX_LIST bgp-as-path="_0_" protocol=bgp action=discard comment="RFC 7607"
@@ -220,6 +222,23 @@ This is not recommanded. Mikrotik will take a very very long time to process all
 /routing filter add chain=GENERIC_PREFIX_LIST bgp-as-path="_(429[0-3][0-9][0-9][0-9][0-9][0-9][0-9])_|_(4294[0-8][0-9][0-9][0-9][0-9][0-9])_" protocol=bgp action=discard comment="RFC 6996 Private ASNs"
 /routing filter add chain=GENERIC_PREFIX_LIST bgp-as-path="_(42949[0-5][0-9][0-9][0-9][0-9])_|_(429496[0-6][0-9][0-9][0-9])_" protocol=bgp action=discard comment="RFC 6996 Private ASNs"
 /routing filter add chain=GENERIC_PREFIX_LIST bgp-as-path="_(4294967[0-1][0-9][0-9])_|_(42949672[0-8][0-9])_|_(429496729[0-4])_" protocol=bgp action=discard comment="RFC 6996 Private ASNs"
+```
+
+### RouterOS v7 
+```
+/routing/filter/num-list 
+add list=BOGON-AS range=0 comment="RFC 7607"
+add list=BOGON-AS range=23456 comment="RFC 4893 AS_TRANS"
+add list=BOGON-AS range=64496-64511" comment="RFC 5398"
+add list=BOGON-AS range=64512-65534" comment="RFC 6996"
+add list=BOGON-AS range=65535 comment="RFC 7300"
+add list=BOGON-AS range=65536-65551" comment="RFC 5398"
+add list=BOGON-AS range=65552-131071 comment="Reserved"
+add list=BOGON-AS range=4200000000-4294967294 comment="RFC 6996"
+add list=BOGON-AS range=4294967294 comment="RFC 7300"
+
+/routing/filter/rule 
+add chain="GENERIC_PREFIX_LIST" rule="if (bgp-as-path [[:BOGON-AS:]]){ reject }"
 ```
 
 ## Huawei VRP

--- a/guides/bogon_prefixes.md
+++ b/guides/bogon_prefixes.md
@@ -117,6 +117,8 @@ ip prefix-list BOGONS_v4 deny 240.0.0.0/4 le 32
 ```
 
 ## Mikrotik
+
+### RouterOS v6
 This is not recommanded. Mikrotik will take a very very long time to process all those routes and has some issues with BGP.
 ```
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ip prefix=0.0.0.0/8 prefix-length=8-32 protocol=bgp action=discard comment="RFC 1122 'this' network"
@@ -133,6 +135,25 @@ This is not recommanded. Mikrotik will take a very very long time to process all
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ip prefix=203.0.113.0/24 prefix-length=24-32 protocol=bgp action=discard comment="RFC 5737 TEST-NET-3"
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ip prefix=224.0.0.0/4 prefix-length=4-32 protocol=bgp action=discard comment="multicast"
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ip prefix=240.0.0.0/4 prefix-length=4-32 protocol=bgp action=discard comment="multicast"
+```
+
+### RouterOS v7
+```
+/routing/filter/rule
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=0.0.0.0/8 && dst-len >= 8 ){ reject; }" comment="RFC 1122 'this' network"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=10.0.0.0/8 && dst-len >= 8){ reject; }" comment="RFC 1918 private space"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=100.64.0.0/10 && dst-len >= 10){ reject; }" comment="RFC 6598 Carrier grade nat space"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=127.0.0.0/8 && dst-len >= 8){ rejecet; }" comment="RFC 1122 localhost"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=169.254.0.0/16 && dst-len >= 16){ reject; }" comment="RFC 3927 link local"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=172.16.0.0/12 && dst-len >= 12){ reject; }" comment="RFC 1918 private space"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=192.0.2.0/24 && dst-len >= 24){ reject; }" comment="RFC 5737 TEST-NET-1"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=192.88.99.0/24 && dst-len >= 24){ reject; }" comment="RFC 7526 6to4 anycast relay"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=192.168.0.0/16 && dst-len >= 16){ reject; }" comment="RFC 1918 private space"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=198.18.0.0/15 && dst-len >= 15){ reject; }" comment="RFC 2544 benchmarking"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=198.51.100.0/24 && dst-len >= 24){ reject; }" comment="RFC 5737 TEST-NET-2"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=203.0.113.0/24 && dst-len >= 24){ reject; }" comment="RFC 5737 TEST-NET-3"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=224.0.0.0/4 && dst-len >= 4){ reject; } comment="multicast"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=240.0.0.0/4 && dst-len >= 4){ reject; } comment="reserved"
 ```
 
 ## Junos
@@ -460,6 +481,8 @@ ipv6 prefix-list BOGONS_v6 deny ff00::/8 le 128
 ```
 
 ## Mikrotik
+
+### RouterOS v6
 This is not recommanded. Mikrotik will take a very very long time to process all those routes and has some issues with BGP.
 ```
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ipv6 prefix=::/8 prefix-length=8-128 protocol=bgp action=discard comment="RFC 4291 IPv4-compatible, loopback, et al"
@@ -473,6 +496,22 @@ This is not recommanded. Mikrotik will take a very very long time to process all
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ipv6 prefix=fe80::/10 prefix-length=10-128 protocol=bgp action=discard comment="RFC 4291 link local unicast"
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ipv6 prefix=fec0::/10 prefix-length=10-128 protocol=bgp action=discard comment="RFC 3879 old site local unicast"
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ipv6 prefix=ff00::/8 prefix-length=8-128 protocol=bgp action=discard comment="RFC 4291 multicast"
+```
+
+### RouterOS v7 
+```
+/routing/filter/rule
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==::/8 && dst-len >= 8 ){ reject;}" comment="RFC 4291 IPv4-compatible, loopback, et al"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==0100::/64 && dst-len >= 64 ){ reject; }" comment="RFC 6666 Discard-Only"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==2001:2::/48 && dst-len >= 48 ){ reject; }" comment="RFC 5180 BMWG"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==2001:10::/28 && dst-len >= 28 ){ reject; }" comment="RFC 4843 ORCHID"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==2001:db8::/32 && dst-len >= 32 ){ reject; }" comment="RFC 3849 documentation"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==2002::/16 && dst-len >= 16 ){ reject; }" comment="RFC 7526 6to4 anycast relay"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==3ffe::/16 && dst-len >= 16){ reject; }" comment="RFC 3701 old 6bone"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==fc00::/7 && dst-len >=7 ){ reject; }" comment="RFC 4193 unique local unicast"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==fe80::/10 && dst-len >= 10){ reject; }" comment="RFC 4291 link local unicast"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==fec0::/10 && dst-len >= 10){ reject; }" comment="RFC 3879 old site local unicast"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && address-family=ipv6 && prefix=ff00::/8 dst-len >= 8) { reject; }" comment="RFC 4291 multicast"
 ```
 
 ## Juniper and Cisco

--- a/guides/bogon_prefixes.md
+++ b/guides/bogon_prefixes.md
@@ -140,20 +140,20 @@ This is not recommanded. Mikrotik will take a very very long time to process all
 ### RouterOS v7
 ```
 /routing/filter/rule
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=0.0.0.0/8 && dst-len >= 8 ){ reject; }" comment="RFC 1122 'this' network"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=10.0.0.0/8 && dst-len >= 8){ reject; }" comment="RFC 1918 private space"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=100.64.0.0/10 && dst-len >= 10){ reject; }" comment="RFC 6598 Carrier grade nat space"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=127.0.0.0/8 && dst-len >= 8){ rejecet; }" comment="RFC 1122 localhost"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=169.254.0.0/16 && dst-len >= 16){ reject; }" comment="RFC 3927 link local"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=172.16.0.0/12 && dst-len >= 12){ reject; }" comment="RFC 1918 private space"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=192.0.2.0/24 && dst-len >= 24){ reject; }" comment="RFC 5737 TEST-NET-1"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=192.88.99.0/24 && dst-len >= 24){ reject; }" comment="RFC 7526 6to4 anycast relay"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=192.168.0.0/16 && dst-len >= 16){ reject; }" comment="RFC 1918 private space"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=198.18.0.0/15 && dst-len >= 15){ reject; }" comment="RFC 2544 benchmarking"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=198.51.100.0/24 && dst-len >= 24){ reject; }" comment="RFC 5737 TEST-NET-2"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=203.0.113.0/24 && dst-len >= 24){ reject; }" comment="RFC 5737 TEST-NET-3"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=224.0.0.0/4 && dst-len >= 4){ reject; } comment="multicast"
-add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst=240.0.0.0/4 && dst-len >= 4){ reject; } comment="reserved"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==0.0.0.0/8 && dst-len >= 8 ){ reject; }" comment="RFC 1122 'this' network"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==10.0.0.0/8 && dst-len >= 8){ reject; }" comment="RFC 1918 private space"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==100.64.0.0/10 && dst-len >= 10){ reject; }" comment="RFC 6598 Carrier grade nat space"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==127.0.0.0/8 && dst-len >= 8){ rejecet; }" comment="RFC 1122 localhost"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==169.254.0.0/16 && dst-len >= 16){ reject; }" comment="RFC 3927 link local"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==172.16.0.0/12 && dst-len >= 12){ reject; }" comment="RFC 1918 private space"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==192.0.2.0/24 && dst-len >= 24){ reject; }" comment="RFC 5737 TEST-NET-1"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==192.88.99.0/24 && dst-len >= 24){ reject; }" comment="RFC 7526 6to4 anycast relay"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==192.168.0.0/16 && dst-len >= 16){ reject; }" comment="RFC 1918 private space"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==198.18.0.0/15 && dst-len >= 15){ reject; }" comment="RFC 2544 benchmarking"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==198.51.100.0/24 && dst-len >= 24){ reject; }" comment="RFC 5737 TEST-NET-2"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==203.0.113.0/24 && dst-len >= 24){ reject; }" comment="RFC 5737 TEST-NET-3"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==224.0.0.0/4 && dst-len >= 4){ reject; }" comment="multicast"
+add chain=GENERIC_PREFIX_LIST rule="if ( afi ipv4 && dst==240.0.0.0/4 && dst-len >= 4){ reject; }" comment="reserved"
 ```
 
 ## Junos
@@ -501,17 +501,17 @@ This is not recommanded. Mikrotik will take a very very long time to process all
 ### RouterOS v7 
 ```
 /routing/filter/rule
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==::/8 && dst-len >= 8 ){ reject;}" comment="RFC 4291 IPv4-compatible, loopback, et al"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==0100::/64 && dst-len >= 64 ){ reject; }" comment="RFC 6666 Discard-Only"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==2001:2::/48 && dst-len >= 48 ){ reject; }" comment="RFC 5180 BMWG"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==2001:10::/28 && dst-len >= 28 ){ reject; }" comment="RFC 4843 ORCHID"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==2001:db8::/32 && dst-len >= 32 ){ reject; }" comment="RFC 3849 documentation"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==2002::/16 && dst-len >= 16 ){ reject; }" comment="RFC 7526 6to4 anycast relay"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==3ffe::/16 && dst-len >= 16){ reject; }" comment="RFC 3701 old 6bone"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==fc00::/7 && dst-len >=7 ){ reject; }" comment="RFC 4193 unique local unicast"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==fe80::/10 && dst-len >= 10){ reject; }" comment="RFC 4291 link local unicast"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && dst==fec0::/10 && dst-len >= 10){ reject; }" comment="RFC 3879 old site local unicast"
-add chain="GENERIC_PREFIX_LIST" rule="if ( afi==ipv6 && address-family=ipv6 && prefix=ff00::/8 dst-len >= 8) { reject; }" comment="RFC 4291 multicast"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==::/8 && dst-len >= 8 ){ reject;}" comment="RFC 4291 IPv4-compatible, loopback, et al"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==0100::/64 && dst-len >= 64 ){ reject; }" comment="RFC 6666 Discard-Only"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==2001:2::/48 && dst-len >= 48 ){ reject; }" comment="RFC 5180 BMWG"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==2001:10::/28 && dst-len >= 28 ){ reject; }" comment="RFC 4843 ORCHID"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==2001:db8::/32 && dst-len >= 32 ){ reject; }" comment="RFC 3849 documentation"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==2002::/16 && dst-len >= 16 ){ reject; }" comment="RFC 7526 6to4 anycast relay"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==3ffe::/16 && dst-len >= 16){ reject; }" comment="RFC 3701 old 6bone"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==fc00::/7 && dst-len >=7 ){ reject; }" comment="RFC 4193 unique local unicast"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==fe80::/10 && dst-len >= 10){ reject; }" comment="RFC 4291 link local unicast"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==fec0::/10 && dst-len >= 10){ reject; }" comment="RFC 3879 old site local unicast"
+add chain="GENERIC_PREFIX_LIST" rule="if ( afi ipv6 && dst==ff00::/8 && dst-len >= 8) { reject; }" comment="RFC 4291 multicast"
 ```
 
 ## Juniper and Cisco

--- a/guides/default_accept.md
+++ b/guides/default_accept.md
@@ -121,3 +121,14 @@ policy-statement "BGP_FILTER_IN" {
         }
     }
 ```
+
+## Mikrotik
+### RouterOS v7
+These should be the last rules in the chain, by default RouterOS will add the new rules to the end of the list. 
+
+```
+/routing/filter/rule
+add chain="GENERIC_PREFIX_LIST" rule="set bgp-local-pref 115;"
+add chain="GENERIC_PREFIX_LIST" rule="append bgp-communities <your ASN>:<peer ASN>;"
+add chain="GENERIC_PREFIX_LIST" rule="accept"
+```

--- a/guides/graceful_shutdown.md
+++ b/guides/graceful_shutdown.md
@@ -184,6 +184,14 @@ policy-statement "BGP_FILTER_IN" {
 }
 ```
 
+## MikroTik 
+### RouterOS v7
+RouterOS 7 added support for several Well-known communities including graceful-shutdown. 
+```
+/routing/filter/rule 
+add chain="GENERIC_PREFIX_LIST" rule="if (bgp-communities includes graceful-shutdown) { set bgp-local-pref 0; }"
+```
+
 ## Huawei VRP
 ```
 ip community-filter basic GRACEFUL-SHUTDOWN index 10 permit 65535:0

--- a/guides/long_paths.md
+++ b/guides/long_paths.md
@@ -64,9 +64,17 @@ deny from any max-as-len 100
 ```
 
 ## Mikrotik
+
+### RouterOS v6
 This is not recommanded. Mikrotik will take a very very long time to process all those routes and has some issues with BGP.
 ```
 /routing filter add chain=GENERIC_PREFIX_LIST bgp-as-path-length="65-4294967295" protocol=bgp action=discard comment=""
+```
+
+### RouterOS v7
+```
+/routing/filter/rule
+add chain="GENERIC_PREFIX_LIST" rule="if (bgp-path-len >= 100 ){ reject }"
 ```
 
 ## Nokia SR OS

--- a/guides/no_transit_leaks.md
+++ b/guides/no_transit_leaks.md
@@ -190,6 +190,33 @@ policy-statement "BGP_FILTER_IN" {
 /configure policy-options policy-statement "BGP_FILTER_IN" entry 50 action action-type reject
 ```
 
+## Mikrotik
+
+### RouterOS v7
+```
+/routing/filter/num-list
+add list="TRANSIT_ASNS" range=174 comment="Cogent" 
+add list="TRANSIT_ASNS" range=701 comment="UUNET" 
+add list="TRANSIT_ASNS" range=1299 comment="Telia" 
+add list="TRANSIT_ASNS" range=2914 comment="NTT Ltd." 
+add list="TRANSIT_ASNS" range=3257 comment="GTT Backbone" 
+add list="TRANSIT_ASNS" range=3320 comment="Deutsche Telekom AG (DTAG)" 
+add list="TRANSIT_ASNS" range=3356 comment="Level3" 
+add list="TRANSIT_ASNS" range=3491 comment="PCCW" 
+add list="TRANSIT_ASNS" range=4134 comment="Chinanet" 
+add list="TRANSIT_ASNS" range=5511 comment="Orange opentransit" 
+add list="TRANSIT_ASNS" range=6453 comment="Tata Communications" 
+add list="TRANSIT_ASNS" range=6461 comment="Zayo Bandwidth" 
+add list="TRANSIT_ASNS" range=6762 comment="Seabone / Telecom Italia" 
+add list="TRANSIT_ASNS" range=6830 comment="Liberty Global"
+add list="TRANSIT_ASNS" range=7018 comment="AT&T"  
+
+/routing/filter/rule 
+add chain="NO-TRANSIT-IN" rule="if (bgp-as-path [[:TRANSIT_ASNS:]]){ reject }"
+```
+
+
+
 ## Huawei VRP
 
 ```

--- a/guides/reject_invalids.md
+++ b/guides/reject_invalids.md
@@ -376,6 +376,26 @@ A:admin@br1-nyc# info
 
  ```
 
+## Mikrotik 
+
+### RouterOS v7
+Since RouterOS v7 MikroTik has added support for RPKI-validation. 
+
+Configure RTR
+```
+/routing/rpki
+add address=10.1.1.6 group=rpki-validator port=323
+```
+
+Now validate the prefixes in the EBGP ingress policy: 
+```
+/routing/filter/rule
+add chain="GENERIC_PREFIX_LIST" rule="rpki-verify rpki-validator"
+add chain="GENERIC_PREFIX_LIST" rule="if (rpki invalid){ reject }"
+```
+
+
+
 ## Huawei VRP
 
 Configure RTR and enable RPKI.

--- a/guides/small_prefixes.md
+++ b/guides/small_prefixes.md
@@ -97,12 +97,23 @@ ipv6 prefix-list BOGONS_v6 deny ::/0 ge 49 le 128
 ```
 
 ## Mikrotik
+
+### RouterOS v6
 This is not recommanded. Mikrotik will take a very very long time to process all those routes and has some issues with BGP.
 ```
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ipv4 prefix-length=0-7 protocol=bgp action=discard comment=""
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ipv4 prefix-length=25-32 protocol=bgp action=discard comment=""
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ipv6 prefix-length=0-15 protocol=bgp action=discard comment=""
 /routing filter add chain=GENERIC_PREFIX_LIST address-family=ipv6 prefix-length=49-128 protocol=bgp action=discard comment=""
+```
+
+### RouterOS v7 
+```
+/routing/filter/rule
+add chain="GENERIC_PREFIX_LIST" rule="if (afi ipv4 && dst-len > 24){ reject }"
+add chain="GENERIC_PREFIX_LIST" rule="if (afi ipv4 && dst-len < 7){ reject }" 
+add chain="GENERIC_PREFIX_LIST" rule="if (afi ipv6 && dst-len > 48){ reject }"
+add chain="GENERIC_PREFIX_LIST" rule="if (afi ipv6 && dst-len < 15){ reject }"
 ```
 
 ## Nokia SR OS


### PR DESCRIPTION
MikroTik RouterOS v7 has a completly rebuild routing-filter setup and syntax. I have added the examples for RouterOS v7 based on their RouterOS v6 counter-parts. 

I suspect that both RouterOS v6 and RouterOS v7 are used in production networks, so I have added the examples including additional headings, this instead of replacing them. In my own experience the warning that was in there for RouterOS v6 doesn't apply for RouterOS v7 so I have left it under the RouterOS v6 examples. 